### PR TITLE
H1 en header

### DIFF
--- a/src/components/Header/__tests__/__snapshots__/header.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/header.tsx.snap
@@ -56,6 +56,8 @@ exports[`Header renders correctly 1`] = `
   font-family: title;
   position: relative;
   top: 5px;
+  margin: 0 1rem;
+  font-weight: 400;
 }
 
 <header

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,7 +1,8 @@
 /** @jsxImportSource theme-ui */
 import HomePageLink from "./homepage-link"
 
-const Header = ({ children }) => {
+const Header = ({ children, isTitle=false }) => {
+  const CustomTag = isTitle ?  `h1`: `span`
   return (
     <header
       sx={{
@@ -22,7 +23,7 @@ const Header = ({ children }) => {
         }}
       >
         <HomePageLink />
-        <span
+        <CustomTag
           sx={{
             ml: 2,
             fontSize: [42],
@@ -30,10 +31,12 @@ const Header = ({ children }) => {
             fontFamily: "title",
             position: "relative",
             top: "5px",
+            margin: "0 1rem",
+            fontWeight: 400
           }}
         >
           {children}
-        </span>
+        </CustomTag>
       </div>
       <div sx={{ mx: "auto" }} />
     </header>

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -8,7 +8,7 @@ import Header from "../components/Header/header"
 import PostList from "../components/Blog/blog-list"
 
 const BlogPosts = ({ data, location }) => (
-  <Layout header={<Header>Blog</Header>} footer={<FooterContainer />}>
+  <Layout header={<Header isTitle>Blog</Header>} footer={<FooterContainer />}>
     <PostList posts={data.allMdx.edges} />
   </Layout>
 )

--- a/src/pages/portafolio.tsx
+++ b/src/pages/portafolio.tsx
@@ -7,8 +7,8 @@ import FooterContainer from "../containers/footer-container"
 import Header from "../components/Header/header"
 import PortfolioList from "../components/Portfolio/portfolio-list"
 
-const PortfolioPosts = ({ data, location }) => (
-  <Layout header={<Header>Portafolio</Header>} footer={ <FooterContainer />}>
+const PortfolioPosts = ({ data }) => (
+  <Layout header={<Header isTitle>Portafolio</Header>} footer={ <FooterContainer />}>
     <PortfolioList posts={data.allMdx.edges} />
   </Layout>
 )


### PR DESCRIPTION
En los listados Blog y portafolio
Header ahora recibe un parámetro llamado isTitle

## Observaciones

Deberia verse igual con la excepción que las páginas de blog y portafolio deben mostrar los h1 correctamente